### PR TITLE
Support for `extends` keyword

### DIFF
--- a/GitLab/Job/Type.dhall
+++ b/GitLab/Job/Type.dhall
@@ -34,4 +34,5 @@ in  { stage : Optional Text
     , environment : Optional Environment
     , trigger : Optional Trigger
     , timeout : Optional Text
+    , extends : Optional (List Text)
     }

--- a/GitLab/Job/Type.dhall
+++ b/GitLab/Job/Type.dhall
@@ -34,5 +34,5 @@ in  { stage : Optional Text
     , environment : Optional Environment
     , trigger : Optional Trigger
     , timeout : Optional Text
-    , extends : Optional (List Text)
+    , extends : List Text
     }

--- a/GitLab/Job/append.dhall
+++ b/GitLab/Job/append.dhall
@@ -59,6 +59,7 @@ let append
         , trigger =
             mergeOptional Trigger.Type Trigger.append a.trigger b.trigger
         , timeout = mergeOptionalRight Text a.timeout b.timeout
+        , extends = mergeOptionalList Text a.extends b.extends
         }
 
 in  append

--- a/GitLab/Job/append.dhall
+++ b/GitLab/Job/append.dhall
@@ -59,7 +59,7 @@ let append
         , trigger =
             mergeOptional Trigger.Type Trigger.append a.trigger b.trigger
         , timeout = mergeOptionalRight Text a.timeout b.timeout
-        , extends = mergeOptionalList Text a.extends b.extends
+        , extends = a.extends # b.extends
         }
 
 in  append

--- a/GitLab/Job/default.dhall
+++ b/GitLab/Job/default.dhall
@@ -34,5 +34,6 @@ in    { stage = None Text
       , environment = None Environment
       , trigger = None Trigger
       , timeout = None Text
+      , extends = None (List Text)
       }
     : ./Type.dhall

--- a/GitLab/Job/default.dhall
+++ b/GitLab/Job/default.dhall
@@ -34,6 +34,6 @@ in    { stage = None Text
       , environment = None Environment
       , trigger = None Trigger
       , timeout = None Text
-      , extends = None (List Text)
+      , extends = [] : List Text
       }
     : ./Type.dhall

--- a/GitLab/Job/toJSON.dhall
+++ b/GitLab/Job/toJSON.dhall
@@ -144,11 +144,17 @@ in  let Job/toJSON
                     , timeout =
                         Optional/map Text JSON.Type JSON.string job.timeout
                     , extends =
-                        Optional/map
-                          (List Text)
-                          JSON.Type
-                          stringsArrayJSON
-                          job.extends
+                        if    Prelude.List.null Text job.extends
+                        then  None JSON.Type
+                        else  Some
+                                ( JSON.array
+                                    ( Prelude.List.map
+                                        Text
+                                        JSON.Type
+                                        JSON.string
+                                        job.extends
+                                    )
+                                )
                     }
 
             in  JSON.object (dropNones Text JSON.Type everything)

--- a/GitLab/Job/toJSON.dhall
+++ b/GitLab/Job/toJSON.dhall
@@ -143,6 +143,12 @@ in  let Job/toJSON
                           job.trigger
                     , timeout =
                         Optional/map Text JSON.Type JSON.string job.timeout
+                    , extends =
+                        Optional/map
+                          (List Text)
+                          JSON.Type
+                          stringsArrayJSON
+                          job.extends
                     }
 
             in  JSON.object (dropNones Text JSON.Type everything)


### PR DESCRIPTION
Adds support for the `extends` keyword (https://docs.gitlab.com/ee/ci/yaml/index.html#extends)
to the `Job` type.

Implemented as simple list of strings.