### PR TITLE
Included files can be a list

### DIFF
--- a/GitLab/Include/Type.dhall
+++ b/GitLab/Include/Type.dhall
@@ -2,7 +2,7 @@ let Rule = ../Rule/Type.dhall
 
 let Include =
       { local : Optional Text
-      , file : Optional Text
+      , file : List Text
       , remote : Optional Text
       , template : Optional Text
       , rules : List Rule

--- a/GitLab/Include/default.dhall
+++ b/GitLab/Include/default.dhall
@@ -3,7 +3,7 @@ let Rule = ../Rule/Type.dhall
 let Include = ./Type.dhall
 
 in    { local = None Text
-      , file = None Text
+      , file = [] : List Text
       , remote = None Text
       , template = None Text
       , rules = [] : List Rule

--- a/GitLab/Include/toJSON.dhall
+++ b/GitLab/Include/toJSON.dhall
@@ -23,7 +23,9 @@ let Include/toJSON
                       JSON.string
                       include.local
                 , file =
-                    Prelude.Optional.map Text JSON.Type JSON.string include.file
+                    if    Prelude.List.null Text include.file
+                    then  None JSON.Type
+                    else  Some (stringsArrayJSON include.file)
                 , remote =
                     Prelude.Optional.map
                       Text

--- a/GitLab/Include/toJSON.dhall
+++ b/GitLab/Include/toJSON.dhall
@@ -10,6 +10,8 @@ let Rule = ../Rule/package.dhall
 
 let dropNones = ../utils/dropNones.dhall
 
+let stringsArrayJSON = ../utils/stringsArrayJSON.dhall
+
 let Include/toJSON
     : Include → JSON.Type
     = λ(include : Include) →

--- a/Prelude.dhall
+++ b/Prelude.dhall
@@ -19,7 +19,8 @@
    This file also provides an import without the integrity check as a slower
    fallback if the user is using a different version of the Dhall interpreter.
 -}
-
   env:DHALL_PRELUDE
-? https://raw.githubusercontent.com/dhall-lang/dhall-lang/v17.0.0/Prelude/package.dhall sha256:0c04cbe34f1f2d408e8c8b8cb0aa3ff4d5656336910f7e86190a6d14326f966d
 ? https://raw.githubusercontent.com/dhall-lang/dhall-lang/v17.0.0/Prelude/package.dhall
+    sha256:10db3c919c25e9046833df897a8ffe2701dc390fa0893d958c3430524be5a43e
+? https://raw.githubusercontent.com/dhall-lang/dhall-lang/v17.0.0/Prelude/package.dhall
+    sha256:10db3c919c25e9046833df897a8ffe2701dc390fa0893d958c3430524be5a43e

--- a/examples/single-job.dhall
+++ b/examples/single-job.dhall
@@ -1,5 +1,6 @@
 let GitLab =
-      https://raw.githubusercontent.com/bgamari/dhall-gitlab-ci/master/package.dhall
+        ../package.dhall
+      ? https://raw.githubusercontent.com/bgamari/dhall-gitlab-ci/master/package.dhall
 
 let Prelude = GitLab.Prelude
 


### PR DESCRIPTION
The files included can be a list. This reduces duplication in a situation where you want to include multiple files from a single repository. For example: 
```
include:
  - project: "gitlab-ci/templates"
    ref: master
    file:
      - "templates/MergeRequest-Pipelines.gitlab-ci.yml"
      - "templates/Common.gitlab-ci.yml"
```

is valid.