### PR TITLE
Add Test Report artifact to generated JSON

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,3 +17,4 @@ jobs:
       - uses: dhall-lang/setup-dhall@v4
       - run: dhall text --file examples/single-job.dhall
       - run: dhall text --file examples/multiple-jobs.dhall
+      - run: dhall text --file examples/inehrit-examples.dhall

--- a/GitLab/ArtifactsSpec/toJSON.dhall
+++ b/GitLab/ArtifactsSpec/toJSON.dhall
@@ -6,8 +6,6 @@ let JSON = Prelude.JSON
 
 let ArtifactsSpec = ../ArtifactsSpec/Type.dhall
 
-let Optional/map = Prelude.Optional.map
-
 let dropNones = ../utils/dropNones.dhall
 
 let When/toJSON = ../When/toJSON.dhall
@@ -16,19 +14,25 @@ let Duration/toJSON = ../Duration/toJSON.dhall
 
 let List/map = Prelude.List.map
 
+let Optional/map = Prelude.Optional.map
+
+let Optional/null = Prelude.Optional.null
+
 in  let ArtifactsSpec/toJSON
         : ArtifactsSpec → JSON.Type
         = λ(cs : ArtifactsSpec) →
-            let obj
-                : Map.Type Text JSON.Type
-                = toMap
-                    { when = When/toJSON cs.when
-                    , expire_in = Duration/toJSON cs.expire_in
-                    , paths =
-                        JSON.array
-                          (List/map Text JSON.Type JSON.string cs.paths)
-                    }
-
-            in  JSON.object obj
+            let initial = { 
+                when = When/toJSON cs.when
+                , expire_in = Duration/toJSON cs.expire_in
+                , paths = 
+                    JSON.array
+                        (List/map Text JSON.Type JSON.string cs.paths)
+              }
+            let obj =  
+              merge { 
+                  Some = (λ(pattern : Text) → (toMap (initial /\ { reports = JSON.object (toMap { junit = JSON.string pattern })}))), 
+                  None =  toMap initial
+              } cs.reports.junit
+            in JSON.object obj
 
     in  ArtifactsSpec/toJSON

--- a/GitLab/Inherit/Type.dhall
+++ b/GitLab/Inherit/Type.dhall
@@ -1,0 +1,13 @@
+-- Several fields either allow you to set a global default (true/false)
+-- or a list of keywords (such as variable names). So we define `Choice`
+-- to represent those fields.
+let Choice = <Defaults : Bool | Keywords : List Text>
+
+-- Implements the `inherit` keyword provided for jobs (https://docs.gitlab.com/ee/ci/yaml/index.html#inherit)
+
+let Inherit = {
+    `default`: Optional Choice,
+    variables: Optional Choice
+}
+
+in { Inherit, Choice }

--- a/GitLab/Inherit/package.dhall
+++ b/GitLab/Inherit/package.dhall
@@ -1,0 +1,7 @@
+let Types = ./Type.dhall
+
+in { Type = Types.Inherit
+, Choice = Types.Choice
+, default = None Types.Inherit
+, toJSON = ./toJSON.dhall
+}

--- a/GitLab/Inherit/toJSON.dhall
+++ b/GitLab/Inherit/toJSON.dhall
@@ -1,0 +1,32 @@
+let Prelude = ../Prelude.dhall
+
+let Optional/map = Prelude.Optional.map
+
+let Map = Prelude.Map
+
+let JSON = Prelude.JSON
+
+let dropNones = ../utils/dropNones.dhall
+
+let Types = ./Type.dhall
+
+let choiceToJSON = λ(choice : Types.Choice) → merge { 
+    Defaults = λ(b : Bool) → JSON.bool b,
+    Keywords = λ(ks : List Text) -> JSON.array
+      ( Prelude.List.map
+          Text
+          JSON.Type
+          JSON.string
+          ks
+      )
+  } choice
+
+let Inherit/toJSON : Types.Inherit → JSON.Type = λ(inherit : Types.Inherit) →
+  let everything = toMap {
+    `default` = Optional/map Types.Choice JSON.Type choiceToJSON inherit.`default`,
+    variables = Optional/map Types.Choice JSON.Type choiceToJSON inherit.variables
+  }
+
+  in  JSON.object (dropNones Text JSON.Type everything)
+
+in  Inherit/toJSON

--- a/GitLab/Job/Type.dhall
+++ b/GitLab/Job/Type.dhall
@@ -16,6 +16,8 @@ let Rule = ../Rule/Type.dhall
 
 let Trigger = ../Trigger/Type.dhall
 
+let Inherit = ../Inherit/package.dhall
+
 in  { stage : Optional Text
     , image : Optional Image
     , variables : Prelude.Map.Type Text Text
@@ -35,4 +37,5 @@ in  { stage : Optional Text
     , trigger : Optional Trigger
     , timeout : Optional Text
     , extends : List Text
+    , inherit : Optional Inherit.Type
     }

--- a/GitLab/Job/append.dhall
+++ b/GitLab/Job/append.dhall
@@ -19,6 +19,8 @@ let Rule = ../Rule/package.dhall
 
 let Trigger = ../Trigger/package.dhall
 
+let Inherit = ../Inherit/package.dhall
+
 let mergeOptional = ../utils/mergeOptional.dhall
 
 let mergeOptionalRight = ../utils/mergeOptionalRight.dhall
@@ -60,6 +62,7 @@ let append
             mergeOptional Trigger.Type Trigger.append a.trigger b.trigger
         , timeout = mergeOptionalRight Text a.timeout b.timeout
         , extends = a.extends # b.extends
+        , inherit = mergeOptionalRight Inherit.Type a.inherit b.inherit
         }
 
 in  append

--- a/GitLab/Job/default.dhall
+++ b/GitLab/Job/default.dhall
@@ -16,6 +16,8 @@ let Environment = ../Environment/Type.dhall
 
 let Trigger = ../Trigger/Type.dhall
 
+let Inherit = ../Inherit/package.dhall
+
 in    { stage = None Text
       , image = None Image
       , variables = Prelude.Map.empty Text Text
@@ -35,5 +37,6 @@ in    { stage = None Text
       , trigger = None Trigger
       , timeout = None Text
       , extends = [] : List Text
+      , inherit = None Inherit.Type
       }
     : ./Type.dhall

--- a/GitLab/Job/toJSON.dhall
+++ b/GitLab/Job/toJSON.dhall
@@ -32,6 +32,10 @@ let Optional/map = Prelude.Optional.map
 
 let Optional/toList = Prelude.Optional.toList
 
+let Inherit = ../Inherit/package.dhall
+
+let Inherit/toJSON = Inherit.toJSON
+
 in  let Job/toJSON
         : Job → JSON.Type
         = λ(job : Job) →
@@ -155,6 +159,8 @@ in  let Job/toJSON
                                         job.extends
                                     )
                                 )
+                    , inherit =
+                        Optional/map Inherit.Type JSON.Type Inherit/toJSON job.inherit
                     }
 
             in  JSON.object (dropNones Text JSON.Type everything)

--- a/GitLab/package.dhall
+++ b/GitLab/package.dhall
@@ -17,4 +17,5 @@
 , Defaults = ./Defaults/package.dhall
 , Service = ./Service/package.dhall
 , CachePolicy = ./CachePolicy/package.dhall
+, Inherit = ./Inherit/package.dhall
 }

--- a/Prelude.dhall
+++ b/Prelude.dhall
@@ -21,5 +21,5 @@
 -}
 
   env:DHALL_PRELUDE
-? https://raw.githubusercontent.com/dhall-lang/dhall-lang/v17.0.0/Prelude/package.dhall sha256:0c04cbe34f1f2d408e8c8b8cb0aa3ff4d5656336910f7e86190a6d14326f966d
+? https://raw.githubusercontent.com/dhall-lang/dhall-lang/v17.0.0/Prelude/package.dhall sha256:10db3c919c25e9046833df897a8ffe2701dc390fa0893d958c3430524be5a43e
 ? https://raw.githubusercontent.com/dhall-lang/dhall-lang/v17.0.0/Prelude/package.dhall

--- a/examples/inherit-examples.dhall
+++ b/examples/inherit-examples.dhall
@@ -1,0 +1,77 @@
+let GitLab = ../package.dhall
+
+let Prelude = GitLab.Prelude
+
+let renderTop = GitLab.Top.toJSON
+
+-- No inheritance setting
+let inherit_absent =
+      GitLab.Job::{
+      , stage = Some "build"
+      , image = Some { name = "alpine:latest", entrypoint = Some [ " " ] }
+      , script = [ "echo 'Hello World'" ]
+      , inherit = None GitLab.Inherit.Type
+      }
+
+-- Use default inheritance setting
+let inherit_inherit_default =
+      GitLab.Job::{
+      , stage = Some "build"
+      , image = Some { name = "alpine:latest", entrypoint = Some [ " " ] }
+      , script = [ "echo 'Hello World'" ]
+      , inherit = Some {
+          `default` = Some (GitLab.Inherit.Choice.Defaults True),
+          variables = None GitLab.Inherit.Choice
+        }
+      }
+
+-- Use variable default setting
+let inherit_variables_default =
+      GitLab.Job::{
+      , stage = Some "build"
+      , image = Some { name = "alpine:latest", entrypoint = Some [ " " ] }
+      , script = [ "echo 'Hello World'" ]
+      , inherit = Some {
+          `default` = None GitLab.Inherit.Choice,
+          variables = Some (GitLab.Inherit.Choice.Defaults True)
+        }
+      }
+
+-- Use variable list 
+let inherit_variables_list =
+      GitLab.Job::{
+      , stage = Some "build"
+      , image = Some { name = "alpine:latest", entrypoint = Some [ " " ] }
+      , script = [ "echo 'Hello World'" ]
+      , inherit = Some {
+          `default` = None GitLab.Inherit.Choice,
+          variables = Some (GitLab.Inherit.Choice.Keywords ["a", "b"])
+        }
+      }
+
+let inherit_all_fields =
+      GitLab.Job::{
+      , stage = Some "build"
+      , image = Some { name = "alpine:latest", entrypoint = Some [ " " ] }
+      , script = [ "echo 'Hello World'" ]
+      , inherit = Some {
+          `default` = Some (GitLab.Inherit.Choice.Defaults True),
+          variables = Some (GitLab.Inherit.Choice.Keywords ["a", "b"])
+        }
+      }
+
+let top = GitLab.Top::{ jobs = toMap { 
+    -- `inherits` field absent
+    inherit_absent,
+    -- `inherits` sets `default` to true.
+    inherit_inherit_default,
+    -- `inherits` sets `variables` to `true`
+    inherit_variables_default,
+    -- `inherits` sets `variables` to a list
+    inherit_variables_list,
+    -- `inherits` sets all fields to a value (not necessarily useful but shows coverage).
+    inherit_all_fields
+  } 
+}
+
+in  Prelude.JSON.renderYAML (renderTop top)

--- a/examples/single-job.dhall
+++ b/examples/single-job.dhall
@@ -6,6 +6,8 @@ let Prelude = GitLab.Prelude
 
 let renderTop = GitLab.Top.toJSON
 
+let When = GitLab.When.Type
+
 let demoJob =
       GitLab.Job::{
       , stage = Some "build"
@@ -13,6 +15,37 @@ let demoJob =
       , script = [ "echo 'Hello World'" ]
       }
 
-let top = GitLab.Top::{ jobs = toMap { generated-job = demoJob } }
+let jobWithReport =
+      GitLab.Job::{
+      , stage = Some "build"
+      , image = Some { name = "alpine:latest", entrypoint = Some [ " " ] }
+      , script = [ "echo 'Hello World'" ]
+      -- generated JSON will include "reports" key
+      , artifacts = Some
+            { when = When.Always
+                  , expire_in.seconds = 365 * 24 * 60 * 60
+                  , paths = [ "report.xml" ]
+                  , reports = { junit = Some "report.xml" }
+            }
+      }
+
+let jobWithoutReport =
+      GitLab.Job::{
+      , stage = Some "build"
+      , image = Some { name = "alpine:latest", entrypoint = Some [ " " ] }
+      , script = [ "echo 'Hello World'" ]
+      -- generated JSON will not include "reports" key
+      , artifacts = Some
+            { when = When.Always
+                  , expire_in.seconds = 365 * 24 * 60 * 60
+                  , paths = [ "foo.xml" ]
+                  , reports = { junit = None Text}
+            }
+      }
+let top = GitLab.Top::{ jobs = toMap { 
+      generated-job = demoJob 
+      , job-with-report = jobWithReport
+      , job-without-report = jobWithoutReport
+} }
 
 in  Prelude.JSON.renderYAML (renderTop top)


### PR DESCRIPTION
The dhall types allow a test report artifact to be specified, but the generated JSON does not actually include the keys, even if the value is present.

This PR fixes the bug, and updates the single-job example to exercise the feature.